### PR TITLE
FROG-884 capture scope of FROG-884 / FROG-845 - conditional attachment of corporate_group

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ This event is triggered after a booking has been made within the HealthEngine pl
 }
 ```
 
+If the booking is associated with a corporate group (directly via the booking model, or via the booking practice), we conditionally attach a corporate group fragment:
+
+```json
+{
+  ...,
+  "corporate_group": {
+    "id": "1234",
+    "name": "Terry Green"
+  }
+}
+
 ### `booking-cancelled`
 
 This event is triggered after a booking has been cancelled on the HealthEngine platform. An example payload is shown below.
@@ -113,6 +124,17 @@ This event is triggered after a booking has been cancelled on the HealthEngine p
   }
 }
 ```
+
+If the booking is associated with a corporate group (directly via the booking model, or via the booking practice), we conditionally attach a corporate group fragment:
+
+```json
+{
+  ...,
+  "corporate_group": {
+    "id": "1234",
+    "name": "Terry Green"
+  }
+}
 
 ### `booking-pre-screening-submitted`
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ If the booking is associated with a corporate group (directly via the booking mo
 
 ```json
 {
-  ...,
   "corporate_group": {
     "id": "1234",
     "name": "Terry Green"
@@ -129,7 +128,6 @@ If the booking is associated with a corporate group (directly via the booking mo
 
 ```json
 {
-  ...,
   "corporate_group": {
     "id": "1234",
     "name": "Terry Green"


### PR DESCRIPTION
seems a bit sinful to attach conditionally when compared to the rest of the payload
this boat kinda sailed though when looking at [FROG-845](https://github.com/HealthEngineAU/megatron/pull/8128/files) (already merged) / the filtering downstream checks whether corp_group is set to avoid processing if it isn't available